### PR TITLE
feat: add client pool requester

### DIFF
--- a/requester/client_pool/pool.go
+++ b/requester/client_pool/pool.go
@@ -1,0 +1,50 @@
+package pool
+
+import (
+	"net/http"
+	"sync"
+)
+
+type ClientPool interface {
+	AddClients(...*http.Client)
+	GetClient(req *http.Request) *http.Client
+}
+
+type clientPoolImpl struct {
+	mutex   *sync.Mutex
+	cond    *sync.Cond
+	clients []*http.Client
+}
+
+func NewClientPool() ClientPool {
+	mutex := new(sync.Mutex)
+	return &clientPoolImpl{
+		mutex:   mutex,
+		cond:    sync.NewCond(mutex),
+		clients: []*http.Client{},
+	}
+}
+
+func (pool *clientPoolImpl) AddClients(clients ...*http.Client) {
+	pool.mutex.Lock()
+	defer pool.mutex.Unlock()
+
+	for _, cli := range clients {
+		pool.clients = append(pool.clients, cli)
+		pool.cond.Signal()
+	}
+}
+
+func (pool *clientPoolImpl) GetClient(req *http.Request) *http.Client {
+	pool.mutex.Lock()
+	defer pool.mutex.Unlock()
+
+	if len(pool.clients) == 0 {
+		pool.cond.Wait()
+	}
+
+	cli := pool.clients[0]
+	pool.clients = pool.clients[1:]
+
+	return cli
+}

--- a/requester/client_pool/pool_test.go
+++ b/requester/client_pool/pool_test.go
@@ -1,0 +1,137 @@
+package pool
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewClientPool(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		wantClientPool clientPoolImpl
+	}{
+		{
+			name: "happy flow",
+			wantClientPool: clientPoolImpl{
+				mutex:   new(sync.Mutex),
+				cond:    sync.NewCond(new(sync.Mutex)),
+				clients: []*http.Client{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pool := NewClientPool()
+			assert.Equal(t, &tt.wantClientPool, pool)
+		})
+	}
+}
+
+func TestClientPoolImpl_AddClients(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		clientsToAdd   []*http.Client
+		initialClients []*http.Client
+		wantClients    []*http.Client
+	}{
+		{
+			name:           "happy flow: add one client to empty pool",
+			clientsToAdd:   []*http.Client{http.DefaultClient},
+			initialClients: []*http.Client{},
+			wantClients:    []*http.Client{http.DefaultClient},
+		},
+		{
+			name:           "happy flow: add multiple clients to empty pool",
+			clientsToAdd:   []*http.Client{http.DefaultClient, http.DefaultClient},
+			initialClients: []*http.Client{},
+			wantClients:    []*http.Client{http.DefaultClient, http.DefaultClient},
+		},
+		{
+			name:           "happy flow: add one client to non-empty pool",
+			clientsToAdd:   []*http.Client{http.DefaultClient},
+			initialClients: []*http.Client{http.DefaultClient},
+			wantClients:    []*http.Client{http.DefaultClient, http.DefaultClient},
+		},
+		{
+			name:           "happy flow: add multiple clients to non-empty pool",
+			clientsToAdd:   []*http.Client{http.DefaultClient, http.DefaultClient},
+			initialClients: []*http.Client{http.DefaultClient},
+			wantClients:    []*http.Client{http.DefaultClient, http.DefaultClient, http.DefaultClient},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pool := &clientPoolImpl{
+				mutex:   new(sync.Mutex),
+				cond:    sync.NewCond(new(sync.Mutex)),
+				clients: tt.initialClients,
+			}
+			pool.AddClients(tt.clientsToAdd...)
+			assert.Equal(t, tt.wantClients, pool.clients)
+		})
+	}
+}
+
+func TestClientPoolImpl_GetClient(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name               string
+		addClientsFunc     func(pool *clientPoolImpl)
+		wantClient         *http.Client
+		wantPoolClients    []*http.Client
+		wantWithinDuration time.Duration
+	}{
+		{
+			name: "happy flow: get first client from pool",
+			addClientsFunc: func(pool *clientPoolImpl) {
+				pool.AddClients(http.DefaultClient, &http.Client{})
+			},
+			wantClient:         http.DefaultClient,
+			wantPoolClients:    []*http.Client{{}},
+			wantWithinDuration: 100 * time.Millisecond,
+		},
+		{
+			name: "edge case: wait until client available",
+			addClientsFunc: func(pool *clientPoolImpl) {
+				go func() {
+					time.Sleep(100 * time.Millisecond)
+					pool.AddClients(http.DefaultClient)
+				}()
+			},
+			wantClient:         http.DefaultClient,
+			wantPoolClients:    []*http.Client{},
+			wantWithinDuration: 200 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mu := new(sync.Mutex)
+			pool := &clientPoolImpl{
+				mutex: mu,
+				cond:  sync.NewCond(mu),
+			}
+			tt.addClientsFunc(pool)
+
+			gotClient := pool.GetClient(&http.Request{})
+			assert.Equal(t, tt.wantClient, gotClient)
+			assert.Equal(t, tt.wantPoolClients, pool.clients)
+		})
+	}
+}

--- a/requester/client_pool/request_recorder.go
+++ b/requester/client_pool/request_recorder.go
@@ -1,0 +1,59 @@
+package pool
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/htchan/goclient"
+)
+
+type RequestRecorder func(pool ClientPool, cli *http.Client, req *http.Request, resp *http.Response, err error)
+
+func NewRequestRecorderAlwaysAddClientBack(cooldownInterval time.Duration) RequestRecorder {
+	return func(pool ClientPool, cli *http.Client, req *http.Request, resp *http.Response, err error) {
+		go func() {
+			time.Sleep(cooldownInterval)
+			pool.AddClients(cli)
+		}()
+	}
+}
+
+func NewRequestRecorderDropClientForContinueFailed(
+	isRequestFail goclient.ResultValidator,
+	failureThreshold int,
+	failureCooldownInterval time.Duration,
+	successCooldownInterval time.Duration,
+) RequestRecorder {
+	failureCounts := make(map[*http.Client]int)
+	lock := new(sync.Mutex)
+	return func(pool ClientPool, cli *http.Client, req *http.Request, resp *http.Response, err error) {
+		lock.Lock()
+		defer lock.Unlock()
+
+		// check failure count
+		cooldownInterval := successCooldownInterval
+
+		failureCount, ok := failureCounts[cli]
+		if !ok {
+			failureCount = 0
+		}
+
+		// update failure count
+		if isRequestFail(req, resp, err) {
+			failureCount += 1
+			cooldownInterval = failureCooldownInterval
+		} else {
+			failureCount = 0
+		}
+		failureCounts[cli] = failureCount
+
+		// create go routine to add client back to pool after cooldown
+		if failureCount < failureThreshold {
+			go func() {
+				time.Sleep(cooldownInterval)
+				pool.AddClients(cli)
+			}()
+		}
+	}
+}

--- a/requester/client_pool/request_recorder_test.go
+++ b/requester/client_pool/request_recorder_test.go
@@ -1,0 +1,118 @@
+package pool
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/htchan/goclient"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRequestRecorderAlwaysAddClientBack(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		cooldownInterval time.Duration
+		wantClients      []*http.Client
+	}{
+		{
+			name:             "happy path",
+			cooldownInterval: 100 * time.Millisecond,
+			wantClients:      []*http.Client{http.DefaultClient},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			requestRecorder := NewRequestRecorderAlwaysAddClientBack(tt.cooldownInterval)
+			pool := clientPoolImpl{
+				mutex:   new(sync.Mutex),
+				cond:    sync.NewCond(new(sync.Mutex)),
+				clients: []*http.Client{},
+			}
+			cli := http.DefaultClient
+
+			requestRecorder(&pool, cli, nil, nil, nil)
+			assert.Equal(t, []*http.Client{}, pool.clients) // because of cooldown
+			time.Sleep(tt.cooldownInterval + 50*time.Millisecond)
+			assert.Equal(t, tt.wantClients, pool.clients)
+		})
+	}
+}
+
+func TestNewRequestRecorderDropClientForContinueFailed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                    string
+		isRequestFail           goclient.ResultValidator
+		failureThreshold        int
+		failureCooldownInterval time.Duration
+		successCooldownInterval time.Duration
+		wantCooldownInterval    time.Duration
+		wantClients             []*http.Client
+	}{
+		{
+			name: "happy path: success request",
+			isRequestFail: func(req *http.Request, resp *http.Response, err error) bool {
+				return false
+			},
+			failureThreshold:        3,
+			failureCooldownInterval: 10000 * time.Millisecond,
+			successCooldownInterval: 100 * time.Millisecond,
+			wantCooldownInterval:    150 * time.Millisecond,
+			wantClients:             []*http.Client{http.DefaultClient},
+		},
+		{
+			name: "happy path: failed request below threshold",
+			isRequestFail: func(req *http.Request, resp *http.Response, err error) bool {
+				return true
+			},
+			failureThreshold:        3,
+			failureCooldownInterval: 100 * time.Millisecond,
+			successCooldownInterval: 10000 * time.Millisecond,
+			wantCooldownInterval:    150 * time.Millisecond,
+			wantClients:             []*http.Client{http.DefaultClient},
+		},
+		{
+			name: "happy path: failed request exceed threshold",
+			isRequestFail: func(req *http.Request, resp *http.Response, err error) bool {
+				return true
+			},
+			failureThreshold:        1,
+			failureCooldownInterval: 50 * time.Millisecond,
+			successCooldownInterval: 50 * time.Millisecond,
+			wantCooldownInterval:    150 * time.Millisecond,
+			wantClients:             []*http.Client{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			requestRecorder := NewRequestRecorderDropClientForContinueFailed(
+				tt.isRequestFail,
+				tt.failureThreshold,
+				tt.failureCooldownInterval,
+				tt.successCooldownInterval,
+			)
+			pool := clientPoolImpl{
+				mutex:   new(sync.Mutex),
+				cond:    sync.NewCond(new(sync.Mutex)),
+				clients: []*http.Client{},
+			}
+			cli := http.DefaultClient
+
+			requestRecorder(&pool, cli, nil, nil, nil)
+			assert.Equal(t, []*http.Client{}, pool.clients) // because of cooldown
+			time.Sleep(tt.wantCooldownInterval)
+			assert.Equal(t, tt.wantClients, pool.clients)
+		})
+	}
+}

--- a/requester/client_pool/requester.go
+++ b/requester/client_pool/requester.go
@@ -1,0 +1,26 @@
+package pool
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/htchan/goclient"
+)
+
+func NewClientPoolRequester(
+	pool ClientPool,
+	recordRequest RequestRecorder,
+) goclient.Requester {
+	return func(req *http.Request) (*http.Response, error) {
+		client := pool.GetClient(req)
+
+		resp, err := client.Do(req)
+		recordRequest(pool, client, req, resp, err)
+
+		if err != nil {
+			return nil, fmt.Errorf("client do request failed: %w", err)
+		}
+
+		return resp, nil
+	}
+}


### PR DESCRIPTION
This PR create client pool requester so continue request can use different client to process the request.

The client pool will always return the first available client. Developer need to implement the new client if they want a custom client selection logic.

> [!note]
> Developer should add the `client` back to `pool` explicitly in `RequestRecorder``
