### PR TITLE
fix(security): upgrade Go from 1.26 to 1.26.2 to fix vulnerabilities

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -11,7 +11,7 @@ on:
     - cron: "0 0 1-7 * 6"
 
 env:
-  GO_VERSION: 1.26.1
+  GO_VERSION: 1.26.2
 
 jobs:
   security-scan:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  GO_VERSION: 1.26.1
+  GO_VERSION: 1.26.2
 
 jobs:
   test:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/htchan/goclient
 
-go 1.26
+go 1.26.2
 
 require (
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
This PR upgrades Go from 1.26 to 1.26.2 to fix 4 standard library vulnerabilities: GO-2026-4947, GO-2026-4946, GO-2026-4870, and GO-2026-4866.